### PR TITLE
Fix amalgamate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,17 +26,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang valgrind
 
+      - name: Amalgamate
+        if: ${{ matrix.for }} == "amalgamated"
+        run: |
+          make amalgamate
+          rm -r src/* tests/* # Get rid of current code
+          cp -r amalgamate/test/* . # Move the amalgamated version in its place (so later stuff works)
+
       - name: Build
         run: |
-          if [ "${{ matrix.for }}" == "regular" ]; then
-            make tests debug
-            elif [ "${{ matrix.for }}" == "amalgamated" ]; then
-            make clean
-            make amalgamate
-            rm -r src/*
-            mv amalgamate/* src/
-            make tests debug
-          fi
+          make tests debug
 
       - name: Run tests (debug)
         run: |

--- a/src/caught.h
+++ b/src/caught.h
@@ -1,6 +1,11 @@
+// The central entrypoint of caught
+// You should include this file from your tests
+// #include "caught.h"
+
 #ifndef CAUGHT_LIB
 #define CAUGHT_LIB
 
+#define _GNU_SOURCE // needed to make compiler happy, since this is the entrypoint
 #include "assertions.h"
 #include "tests.h"
 

--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -50,6 +50,7 @@ def find_files(directory, extension):
         for file in files:
             if file.endswith(extension):
                 matched_files.append(os.path.join(root, file))
+    matched_files.sort() # needed for consistency on all platforms
     return matched_files
 
 def amalgamate(out_file: TextIOWrapper, filename: str, c: bool = False):

--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -8,10 +8,10 @@ SRC_DIR = "./src"
 OUT_H = "./amalgamate/caught.h"
 OUT_C = "./amalgamate/caught.c"
 
-COLLAPSE_C_INCLUDES = '#include "caught.h"\n'
+LIB_INCLUDE_FROM_C = '#include "caught.h"\n' # Singularly include entire lib for c file
 
 ENTRY_POINT_C = path.join(SRC_DIR, "main.c")
-ENTRY_POINT_H = path.join(SRC_DIR, "lib.h")
+ENTRY_POINT_H = path.join(SRC_DIR, "caught.h")
 
 with open("LICENSE.txt", "r") as h:
     LICENSE = "".join(h.readlines()[:-2])
@@ -70,9 +70,6 @@ def amalgamate(out_file: TextIOWrapper, filename: str, c: bool = False):
                 continue
 
             if c:
-                if COLLAPSE_C_INCLUDES not in defined_includes:
-                    defined_includes.add(COLLAPSE_C_INCLUDES)
-                    out_file.write(COLLAPSE_C_INCLUDES)
                 continue
 
             rel_header = match.group(1)
@@ -90,6 +87,7 @@ print(f"Amalgamate to: {OUT_H} and {OUT_C}")
 
 with open(OUT_H, "w") as h:
     h.write(HEADER)
+
     amalgamate(h, ENTRY_POINT_H)
 
     # grab any missed h files
@@ -99,6 +97,7 @@ with open(OUT_H, "w") as h:
 
 with open(OUT_C, "w") as c:
     c.write(HEADER)
+    c.write(LIB_INCLUDE_FROM_C)
 
     # grab all c files (order doesn't matter now)
     for file in find_files(SRC_DIR, ".c"):


### PR DESCRIPTION
- Makes amalgamate consistent on all platforms (no longer relying on os.walk impl)
- Fixed the amalgamate entrypoint (`lib.h` -> `caught.h`)
- Added local testing support for amalgamate to make debugging these issues easier in the future
- Fixed workflow to use these changes