### PR TITLE
Add stdout mocking

### DIFF
--- a/src/caught.h
+++ b/src/caught.h
@@ -7,6 +7,7 @@
 
 #define _GNU_SOURCE // needed to make compiler happy, since this is the entrypoint
 #include "assertions.h"
+#include "mocks.h"
 #include "tests.h"
 
 #endif

--- a/src/fork.h
+++ b/src/fork.h
@@ -27,6 +27,7 @@ caught_internal_process_status create_caught_internal_process_status(int type, i
 
 #define CAUGHT_INTERNAL_FORK(child_execute_block)                                              \
     caught_internal_process_status caught_internal_fork_child_status = {};                     \
+    fflush(NULL);                                                                              \
     pid_t caught_internal_pid = fork();                                                        \
     if (caught_internal_pid == -1)                                                             \
     {                                                                                          \

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,12 @@ int main()
 
         test.handler();
 
+        if (caught_internal_state.original_stdout != -1)
+        {
+            perror("Caught: must restore stdout after mocking it, did you forget to call RESTORE_STDOUT()?");
+            exit(EXIT_FAILURE);
+        }
+
         int this_assertions = caught_internal_state.assertions - prev_assertions;
         int this_passed_assertions = caught_internal_state.passed_assertions - prev_passed_assertions;
         int this_failed_assertions = this_assertions - this_passed_assertions;

--- a/src/mocks.c
+++ b/src/mocks.c
@@ -24,6 +24,8 @@ void MOCK_STDOUT()
 
     caught_internal_state.original_stdout = dup(STDOUT_FILENO);
 
+    fflush(NULL);
+
     if (caught_internal_state.original_stdout == -1)
     {
         perror("Caught: failed to dup stdout before mocking stdout");
@@ -44,6 +46,8 @@ char *RESTORE_STDOUT()
         perror("Caught: cannot restore mock not mocked stdout");
         exit(EXIT_FAILURE);
     }
+
+    fflush(NULL);
 
     close(caught_internal_state.mocked_stdout_pipe[1]);
 

--- a/src/mocks.c
+++ b/src/mocks.c
@@ -1,0 +1,100 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "mocks.h"
+#include "state.h"
+
+void MOCK_STDOUT()
+{
+    if (caught_internal_state.original_stdout != -1)
+    {
+        perror("Caught: cannot mock already mocked stdout");
+        exit(EXIT_FAILURE);
+    }
+
+    int pipe_status = pipe(caught_internal_state.mocked_stdout_pipe);
+
+    if (pipe_status == -1)
+    {
+        perror("Caught: failed to create pipe for mocked stdout");
+        exit(EXIT_FAILURE);
+    }
+
+    caught_internal_state.original_stdout = dup(STDOUT_FILENO);
+
+    if (caught_internal_state.original_stdout == -1)
+    {
+        perror("Caught: failed to dup stdout before mocking stdout");
+        exit(EXIT_FAILURE);
+    }
+
+    if (dup2(caught_internal_state.mocked_stdout_pipe[1], STDOUT_FILENO) == -1)
+    {
+        perror("Caught: failed to dup2 pipe to stdout");
+        exit(EXIT_FAILURE);
+    }
+}
+
+char *RESTORE_STDOUT()
+{
+    if (caught_internal_state.original_stdout == -1)
+    {
+        perror("Caught: cannot restore mock not mocked stdout");
+        exit(EXIT_FAILURE);
+    }
+
+    close(caught_internal_state.mocked_stdout_pipe[1]);
+
+    if (dup2(caught_internal_state.original_stdout, STDOUT_FILENO) == -1)
+    {
+        perror("Caught: failed to restore stdout");
+        exit(EXIT_FAILURE);
+    }
+
+    char *result = malloc(RESTORE_STDOUT_BUFFER_SIZE);
+    int result_size = 0;
+    int result_capacity = RESTORE_STDOUT_BUFFER_SIZE;
+
+    char *buffer = malloc(RESTORE_STDOUT_BUFFER_SIZE);
+
+    while (1)
+    {
+        ssize_t size = read(caught_internal_state.mocked_stdout_pipe[0], buffer, RESTORE_STDOUT_BUFFER_SIZE);
+
+        if (size == -1)
+        {
+            perror("Caught: failed to read pipe");
+            exit(EXIT_FAILURE);
+        }
+
+        if (size == 0)
+        {
+            break;
+        }
+
+        memcpy(result + result_size, buffer, size);
+
+        result_size += size;
+
+        if (result_size + RESTORE_STDOUT_BUFFER_SIZE >= result_capacity)
+        {
+            result_capacity *= RESTORE_STDOUT_RESULT_GROW_RATE;
+            buffer = realloc(buffer, result_capacity);
+        }
+    }
+
+    free(buffer);
+    buffer = NULL;
+
+    result[result_size] = '\0';
+
+    close(caught_internal_state.mocked_stdout_pipe[0]);
+
+    caught_internal_state.mocked_stdout_pipe[0] = -1;
+    caught_internal_state.mocked_stdout_pipe[1] = -1;
+    caught_internal_state.original_stdout = -1;
+
+    return result;
+}

--- a/src/mocks.h
+++ b/src/mocks.h
@@ -1,0 +1,10 @@
+#ifndef CAUGHT_MOCKS
+#define CAUGHT_MOCKS
+
+static const int RESTORE_STDOUT_BUFFER_SIZE = 1024;
+static const int RESTORE_STDOUT_RESULT_GROW_RATE = 2;
+
+void MOCK_STDOUT();
+char *RESTORE_STDOUT();
+
+#endif

--- a/src/state.c
+++ b/src/state.c
@@ -6,4 +6,6 @@ struct caught_internal_t caught_internal_state = {
     .tests = NULL,
     .tests_num = 0,
     .tests_capacity = 0,
+    .mocked_stdout_pipe = {-1, -1},
+    .original_stdout = -1,
 };

--- a/src/state.h
+++ b/src/state.h
@@ -1,5 +1,7 @@
 #include <stddef.h>
+
 #include "tests.h"
+
 #ifndef CAUGHT_STATE
 #define CAUGHT_STATE
 
@@ -12,6 +14,8 @@ struct caught_internal_t
     caught_internal_test *tests;
     int tests_num;
     int tests_capacity;
+    int mocked_stdout_pipe[2];
+    int original_stdout;
 };
 
 extern struct caught_internal_t caught_internal_state;

--- a/tests/stdout.c
+++ b/tests/stdout.c
@@ -1,0 +1,22 @@
+// NOTE: The location of this include might differ in your code depending on location
+// For example, it could be: #include "caught.h"
+#include "../src/caught.h"
+
+TEST("stdout - hello world")
+{
+    MOCK_STDOUT();
+    puts("Hello, world!");
+    char *stdout = RESTORE_STDOUT();
+    EXPECT_STR(stdout, ==, "Hello, world!\n");
+}
+
+TEST("stdout - a lot of text")
+{
+    MOCK_STDOUT();
+    puts("The answer to life,");
+    puts("the universe,");
+    puts("and everything,");
+    puts("is 42.");
+    char *stdout = RESTORE_STDOUT();
+    EXPECT_STR(stdout, ==, "The answer to life,\nthe universe,\nand everything,\nis 42.\n");
+}

--- a/tests/stdout.c
+++ b/tests/stdout.c
@@ -6,8 +6,9 @@ TEST("stdout - hello world")
 {
     MOCK_STDOUT();
     puts("Hello, world!");
-    char *stdout = RESTORE_STDOUT();
-    EXPECT_STR(stdout, ==, "Hello, world!\n");
+    char *out = RESTORE_STDOUT();
+    EXPECT_STR(out, ==, "Hello, world!\n");
+    free(out);
 }
 
 TEST("stdout - a lot of text")
@@ -17,6 +18,7 @@ TEST("stdout - a lot of text")
     puts("the universe,");
     puts("and everything,");
     puts("is 42.");
-    char *stdout = RESTORE_STDOUT();
-    EXPECT_STR(stdout, ==, "The answer to life,\nthe universe,\nand everything,\nis 42.\n");
+    char *out = RESTORE_STDOUT();
+    EXPECT_STR(out, ==, "The answer to life,\nthe universe,\nand everything,\nis 42.\n");
+    free(out);
 }


### PR DESCRIPTION
Resolves #8 

Adds:
- `void MOCK_STDOUT()` - begin mocking stdout
- `char* RESTORE_STDOUT()` - finish mocking stdout, returns string of all stdout during that time