### PR TITLE
Fix caught output going to mock

### DIFF
--- a/src/caught.h
+++ b/src/caught.h
@@ -7,9 +7,6 @@
 #define CAUGHT_VERSION_PATCH 0
 #define CAUGHT_VERSION_STRING "v0.3.0"
 
-#define _GNU_SOURCE                                     // needed to make compiler happy, since this is the entrypoint
-extern int asprintf(char **strp, const char *fmt, ...); // sometimes also needed
-
 #ifndef CAUGHT_LIB
 #define CAUGHT_LIB
 

--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,7 @@ int main()
 {
     caught_internal_initialize_color_output();
 
-    printf("\n");
+    caught_output_printf("\n");
     caught_output_header();
 
     int passed_tests = 0;
@@ -45,7 +45,7 @@ int main()
         if (!output)
             continue;
 
-        printf("\n");
+        caught_output_printf("\n");
         caught_output_test_summary(test.name, this_passed_assertions, this_failed_assertions);
     }
 
@@ -54,7 +54,7 @@ int main()
     int passed_assertions = caught_internal_state.passed_assertions;
     int failed_assertions = caught_internal_state.assertions - caught_internal_state.passed_assertions;
 
-    printf("\n");
+    caught_output_printf("\n");
     caught_output_summary("Tests:      ", passed_tests, failed_tests);
     caught_output_summary("Assertions: ", passed_assertions, failed_assertions);
     caught_output_overall_result(failed_tests == 0);

--- a/src/mocks.c
+++ b/src/mocks.c
@@ -1,5 +1,8 @@
 #include <unistd.h>
 #include <stdlib.h>
+#ifndef __USE_POSIX
+#define __USE_POSIX
+#endif
 #include <stdio.h>
 #include <string.h>
 
@@ -28,6 +31,13 @@ void MOCK_STDOUT()
     if (caught_internal_state.original_stdout == -1)
     {
         caught_output_perrorf("Failed to dup stdout before mocking stdout");
+    }
+
+    caught_internal_state.original_stdout_file = fdopen(caught_internal_state.original_stdout, "w");
+
+    if (caught_internal_state.original_stdout_file == NULL)
+    {
+        caught_output_perrorf("Failed to open file descriptor to original stdout");
     }
 
     if (dup2(caught_internal_state.mocked_stdout_pipe[1], STDOUT_FILENO) == -1)
@@ -93,6 +103,9 @@ char *RESTORE_STDOUT()
     caught_internal_state.mocked_stdout_pipe[0] = -1;
     caught_internal_state.mocked_stdout_pipe[1] = -1;
     caught_internal_state.original_stdout = -1;
+
+    fclose(caught_internal_state.original_stdout_file);
+    caught_internal_state.original_stdout_file = NULL;
 
     return result;
 }

--- a/src/output.h
+++ b/src/output.h
@@ -15,10 +15,12 @@ void caught_output_info();
 void caught_output_bold();
 void caught_output_reset();
 
-void caught_output_header();
 void caught_output_internal_error(bool use_perror, char *fstr, va_list args);
 void caught_output_perrorf(char *fstr, ...);
 void caught_output_errorf(char *fstr, ...);
+void caught_output_printf(char *fstr, ...);
+
+void caught_output_header();
 void caught_output_status_tag(int pass);
 void caught_output_assertion_result(caught_internal_assertion_result assertion_result);
 void caught_output_test_summary(const char *test_name, int passed, int failed);

--- a/src/state.c
+++ b/src/state.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 
 #include "state.h"
 #include "mocks.h"
@@ -11,6 +12,8 @@ struct caught_internal_t caught_internal_state = {
     .tests_capacity = 0,
     .mocked_stdout_pipe = {-1, -1},
     .original_stdout = -1,
+    .original_stdout_file = NULL,
+    .is_parent = 1,
 };
 
 void caught_internal_cleanup_state()

--- a/src/state.h
+++ b/src/state.h
@@ -1,4 +1,6 @@
 #include <stddef.h>
+#include <stdbool.h>
+#include <stdio.h>
 
 #include "tests.h"
 
@@ -16,6 +18,8 @@ struct caught_internal_t
     int tests_capacity;
     int mocked_stdout_pipe[2];
     int original_stdout;
+    FILE *original_stdout_file;
+    bool is_parent;
 };
 
 extern struct caught_internal_t caught_internal_state;

--- a/tests/stdout.c
+++ b/tests/stdout.c
@@ -22,3 +22,13 @@ TEST("stdout - a lot of text")
     EXPECT_STR(out, ==, "The answer to life,\nthe universe,\nand everything,\nis 42.\n");
     free(out);
 }
+
+TEST("stdout - with expect")
+{
+    MOCK_STDOUT();
+    puts("This is fun!");
+    EXPECT_INT(1 + 1, ==, 2);
+    char *out = RESTORE_STDOUT();
+    EXPECT_STR(out, ==, "This is fun!\n");
+    free(out);
+}


### PR DESCRIPTION
Prevents expects when caught is mocked from going to the mock. This should also allow expects within mocks to work properly.