### PR TITLE
Fix MOCK_STDOUT blocking forever with empty output

### DIFF
--- a/src/fork.h
+++ b/src/fork.h
@@ -37,7 +37,7 @@ caught_internal_process_status create_caught_internal_process_status(int type, i
     }                                                                                          \
     if (caught_internal_pid == 0)                                                              \
     {                                                                                          \
-        caught_internal_cleanup_state();                                                       \
+        caught_internal_cleanup_state(false);                                                  \
         child_execute_block                                                                    \
                                                                                                \
             caught_output_perrorf("Fork segment must call exit to prevent fork bombs\n");      \

--- a/src/main.c
+++ b/src/main.c
@@ -59,7 +59,7 @@ int main()
     caught_output_summary("Assertions: ", passed_assertions, failed_assertions);
     caught_output_overall_result(failed_tests == 0);
 
-    caught_internal_cleanup_state();
+    caught_internal_cleanup_state(true);
 
     return failed_tests != 0;
 }

--- a/src/state.c
+++ b/src/state.c
@@ -16,7 +16,7 @@ struct caught_internal_t caught_internal_state = {
     .is_parent = 1,
 };
 
-void caught_internal_cleanup_state()
+void caught_internal_cleanup_state(bool exiting)
 {
     if (caught_internal_state.tests)
     {
@@ -26,7 +26,7 @@ void caught_internal_cleanup_state()
         caught_internal_state.tests_capacity = 0;
     }
 
-    if (caught_internal_state.original_stdout != -1)
+    if (exiting && caught_internal_state.original_stdout != -1)
     {
         RESTORE_STDOUT();
     }

--- a/src/state.h
+++ b/src/state.h
@@ -24,6 +24,6 @@ struct caught_internal_t
 
 extern struct caught_internal_t caught_internal_state;
 
-void caught_internal_cleanup_state();
+void caught_internal_cleanup_state(bool exiting);
 
 #endif

--- a/tests/stdout.c
+++ b/tests/stdout.c
@@ -23,12 +23,32 @@ TEST("stdout - a lot of text")
     free(out);
 }
 
-TEST("stdout - with expect")
+TEST("stdout - with generic expect")
 {
     MOCK_STDOUT();
     puts("This is fun!");
     EXPECT_INT(1 + 1, ==, 2);
     char *out = RESTORE_STDOUT();
     EXPECT_STR(out, ==, "This is fun!\n");
+    free(out);
+}
+
+TEST("stdout - no output")
+{
+    MOCK_STDOUT();
+    char *out = RESTORE_STDOUT();
+    EXPECT_STR(out, ==, "");
+    free(out);
+}
+
+TEST("stdout - with expect exit")
+{
+    MOCK_STDOUT();
+    EXPECT_EXIT(1, {
+        puts("Hello!");
+        exit(1);
+    });
+    char *out = RESTORE_STDOUT();
+    EXPECT_STR(out, ==, "Hello!\n");
     free(out);
 }


### PR DESCRIPTION
Fixes:
- Forking asserts like `EXPECT_EXIT` cleaning up mocks, causing no output when expected
- `MOCK_STDOUT` blocking forever with empty output, leading to confusing Caught output