### PR TITLE
Fix defines

### DIFF
--- a/src/formatters.c
+++ b/src/formatters.c
@@ -1,6 +1,8 @@
 #include "formatters.h"
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <stdio.h>
 
 char *caught_internal_formatter_ptr(void *value)

--- a/src/formatters.h
+++ b/src/formatters.h
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <string.h>
 #include <stdbool.h>
 #include "fork.h"


### PR DESCRIPTION
Fixes `#define _GNU_SOURCE` to use `#ifdef` so other definitions outside of caught will not cause issues